### PR TITLE
Fix empty epg_lang field

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -81,6 +81,9 @@ if (isset($_POST["submit_stream"])) {
     } else {
         $rArray["delay_minutes"] = 0;
     }
+    if( empty($_POST['epg_lang']) ){
+        $rArray["epg_lang"] = null;
+    }
     foreach($_POST as $rKey => $rValue) {
         if (isset($rArray[$rKey])) {
             $rArray[$rKey] = $rValue;


### PR DESCRIPTION
in case that the epg only available in one language the field epg_lang is empty (in the DB) and should be NULL