### PR TITLE
Fix parent_category in movie_category.php

### DIFF
--- a/movie_category.php
+++ b/movie_category.php
@@ -40,8 +40,8 @@ if (isset($_POST["submit_category"])) {
     }
 }
 
+$rCategories = getCategories("movie");
 if (isset($_GET["id"])) {
-    $rCategories = getCategories("movie");
     $rCategoryArr = $rCategories[$_GET["id"]];
     if (!$rCategoryArr) {
         exit;


### PR DESCRIPTION
Is necessary get all movie categories in all of case, in edit and add category.
if the categories are obtained in the if statement when you add new category this allow add 'live' parent category and after this not show in movies categories