### PR TITLE
Fix movie categories

### DIFF
--- a/movie_categories.php
+++ b/movie_categories.php
@@ -24,7 +24,7 @@ if (isset($_POST["categories"])) {
                 $db->query("UPDATE `streams` SET `category_id` = 0 WHERE `category_id` = ".intval($rCategoryID).";");
             }
         }
-        $rCategories = getCategories(); // Update
+        $rCategories = getCategories("movie");
     }
 }
 
@@ -64,7 +64,7 @@ include "header.php"; ?>
                     <div class="col-xl-12">
                         <div class="card">
                             <div class="card-body">
-                                <form action="./stream_categories.php" method="POST" id="stream_categories_form">
+                                <form action="./movie_categories.php" method="POST" id="movie_categories_form">
                                     <input type="hidden" id="categories_input" name="categories" value="" />
                                     <div id="basicwizard">
                                         <ul class="nav nav-pills bg-light nav-justified form-wizard-header mb-4">
@@ -185,7 +185,7 @@ include "header.php"; ?>
         }
         $(document).ready(function() {
             $("#category_order").nestable({maxDepth: 2});
-            $("#stream_categories_form").submit(function(e){
+            $("#movie_categories_form").submit(function(e){
                 $("#categories_input").val(JSON.stringify($('.dd').nestable('serialize')));
             });
             

--- a/movie_categories.php
+++ b/movie_categories.php
@@ -24,7 +24,7 @@ if (isset($_POST["categories"])) {
                 $db->query("UPDATE `streams` SET `category_id` = 0 WHERE `category_id` = ".intval($rCategoryID).";");
             }
         }
-        $rCategories = getCategories("movie");
+        $rCategories = getCategories("movie"); // Update
     }
 }
 

--- a/movie_category.php
+++ b/movie_category.php
@@ -40,8 +40,8 @@ if (isset($_POST["submit_category"])) {
     }
 }
 
+$rCategories = getCategories("movie");
 if (isset($_GET["id"])) {
-    $rCategories = getCategories("movie");
     $rCategoryArr = $rCategories[$_GET["id"]];
     if (!$rCategoryArr) {
         exit;


### PR DESCRIPTION
### Fix movie_cagetory.php
Is necessary get all movie categories in all of case, in edit and add category.
if the categories are obtained in the if statement when you add new category this allow add 'live' parent category and after this not show in movies categories

### Fix movies_categories.php
This fix eliminates the bug in which when you reorder the vod categoires this elimminate the 'live' categories (POST action= stream_categories.php and not movie_categories.php